### PR TITLE
[NeoForge 1.21.1] Controlify integration for controller support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,19 @@ repositories {
     // flatDir {
     //    dir 'libs'
     // }
-    
+
     maven {
         url "https://cursemaven.com"
         content {
             includeGroup "curse.maven"
         }
+    }
+
+    // TODO: Use Controlify from Modrinth maven once this PR is published: https://github.com/isXander/Controlify/pull/689
+    //  and then remove this temporary Maven.
+    exclusiveContent {
+        forRepository { maven { url "https://echoellet.github.io/Controlify/" } }
+        filter { includeGroup "dev.echoellet" }
     }
 }
 
@@ -88,6 +95,9 @@ configurations {
 
 dependencies {
     implementation "curse.maven:epic-fight-mod-405076:7132918"
+
+    // Change "compileOnly" to "implementation" for testing in-game.
+    implementation "dev.echoellet:controlify:2.4.2-1.21.1-neoforge"
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/src/main/java/com/yesman/epicskills/EpicSkills.java
+++ b/src/main/java/com/yesman/epicskills/EpicSkills.java
@@ -1,5 +1,7 @@
 package com.yesman.epicskills;
 
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import com.mojang.logging.LogUtils;
@@ -92,4 +94,8 @@ public class EpicSkills {
         	event.enqueueWork(CategorySlotTexture.ENUM_MANAGER::loadEnum);
         }
 	}
+
+    public static @NotNull ResourceLocation rl(@NotNull String path) {
+        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
 }

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillInfoScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillInfoScreen.java
@@ -1,7 +1,5 @@
 package com.yesman.epicskills.client.gui.screen;
 
-import java.util.Set;
-
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.yesman.epicskills.EpicSkills;
 import com.yesman.epicskills.neoforge.attachment.AbilityPoints;
@@ -10,7 +8,6 @@ import com.yesman.epicskills.network.client.ClientBoundUnlockNode;
 import com.yesman.epicskills.network.server.ServerBoundUnlockSkillRequest;
 import com.yesman.epicskills.registry.entry.EpicSkillsAttachmentTypes;
 import com.yesman.epicskills.skilltree.SkillTree;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -33,13 +30,20 @@ import yesman.epicfight.network.client.CPChangeSkill;
 import yesman.epicfight.skill.SkillContainer;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 
+import java.util.Set;
+
 @OnlyIn(Dist.CLIENT)
 public class SkillInfoScreen extends SkillBookScreen {
 	private final Holder.Reference<SkillTree> skillTree;
 	private final SkillTreeProgression.TopDownTreeNode node;
 	private final AbilityPoints abilityPoints;
 	private boolean backgroundMode;
-	
+    private Button actionButton;
+
+    public Button getActionButton() {
+        return actionButton;
+    }
+
 	public SkillInfoScreen(Player opener, Holder.Reference<SkillTree> skillTree, SkillTreeProgression.TopDownTreeNode node, Screen parentScreen) {
 		super(opener, node.nodeInfo().skill(), null, parentScreen);
 		
@@ -81,7 +85,7 @@ public class SkillInfoScreen extends SkillBookScreen {
 			active = false;
 		}
 		
-		Button actionButton =
+		actionButton =
 			Button.builder(
 				message,
 				button -> {

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
@@ -1,23 +1,8 @@
 package com.yesman.epicskills.client.gui.screen;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.function.Function;
-
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.BufferUploader;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.Tesselator;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.*;
 import com.mojang.datafixers.util.Pair;
 import com.yesman.epicskills.EpicSkills;
 import com.yesman.epicskills.client.gui.screen.SkillTreeScreen.TreePage.NodeButton;
@@ -32,16 +17,10 @@ import com.yesman.epicskills.network.server.ServerBoundConvertAbilityPointReques
 import com.yesman.epicskills.registry.entry.EpicSkillsAttachmentTypes;
 import com.yesman.epicskills.registry.entry.EpicSkillsSounds;
 import com.yesman.epicskills.skilltree.SkillTree;
-
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.AbstractButton;
-import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.components.Renderable;
-import net.minecraft.client.gui.components.Tooltip;
-import net.minecraft.client.gui.components.WidgetSprites;
+import net.minecraft.client.gui.components.*;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.layouts.LayoutElement;
 import net.minecraft.client.gui.narration.NarrationElementOutput;
@@ -63,6 +42,8 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.logging.log4j.Logger;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
@@ -72,6 +53,9 @@ import yesman.epicfight.network.EpicFightNetworkManager;
 import yesman.epicfight.registry.entries.EpicFightItems;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.capabilities.skill.PlayerSkills;
+
+import java.util.*;
+import java.util.function.Function;
 
 @OnlyIn(Dist.CLIENT)
 public class SkillTreeScreen extends Screen implements BackgroundRenderableScreen {
@@ -102,7 +86,11 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	private boolean backgroundMode;
 	private boolean synclock;
 	private boolean discarded = false;
-	
+    /**
+     * Whether to ignore {@link SkillTreeScreen#mouseDragged} calls.
+     */
+    private boolean disableMouseDragging = false;
+
 	private int nodeScale = -1;
 	
 	public SkillTreeScreen(LocalPlayerPatch playerpatch) {
@@ -287,6 +275,9 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	
 	@Override
 	public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+        if (isDisableMouseDragging()) {
+            return false;
+        }
 		if (!super.mouseDragged(mouseX, mouseY, button, dragX, dragY)) {
 			this.currentPage.pageLeft += dragX;
 			this.currentPage.pageTop += dragY;
@@ -359,7 +350,15 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	public boolean discarded() {
 		return this.discarded;
 	}
-	
+
+    public boolean isDisableMouseDragging() {
+        return disableMouseDragging;
+    }
+
+    public void setDisableMouseDragging(boolean disableMouseDragging) {
+        this.disableMouseDragging = disableMouseDragging;
+    }
+
 	@OnlyIn(Dist.CLIENT)
 	public class TreeSelectButton extends Button implements HoverSoundPlayer {
 		protected static final WidgetSprites SPRITES = new WidgetSprites(

--- a/src/main/java/com/yesman/epicskills/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/yesman/epicskills/compat/controlify/ControlifyCompat.java
@@ -1,0 +1,168 @@
+package com.yesman.epicskills.compat.controlify;
+
+import com.yesman.epicskills.EpicSkills;
+import com.yesman.epicskills.client.gui.screen.SkillInfoScreen;
+import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
+import com.yesman.epicskills.client.input.EpicSkillsKeyMappings;
+import dev.isxander.controlify.InputMode;
+import dev.isxander.controlify.api.ControlifyApi;
+import dev.isxander.controlify.api.bind.ControlifyBindApi;
+import dev.isxander.controlify.api.bind.InputBindingSupplier;
+import dev.isxander.controlify.api.buttonguide.ButtonGuideApi;
+import dev.isxander.controlify.api.buttonguide.ButtonGuidePredicate;
+import dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint;
+import dev.isxander.controlify.api.entrypoint.InitContext;
+import dev.isxander.controlify.api.entrypoint.PreInitContext;
+import dev.isxander.controlify.bindings.BindContext;
+import dev.isxander.controlify.bindings.ControlifyBindings;
+import dev.isxander.controlify.bindings.RadialIcons;
+import dev.isxander.controlify.controller.ControllerEntity;
+import dev.isxander.controlify.screenop.ScreenProcessor;
+import dev.isxander.controlify.screenop.ScreenProcessorProvider;
+import dev.isxander.controlify.utils.render.Blit;
+import dev.isxander.controlify.utils.render.CGuiPose;
+import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+
+public class ControlifyCompat implements ControlifyEntrypoint {
+    private static InputBindingSupplier openSkillTreeScreen;
+
+    @Override
+    public void onControllersDiscovered(ControlifyApi controlify) {
+
+    }
+
+    @Override
+    public void onControlifyInit(InitContext context) {
+
+    }
+
+    @Override
+    public void onControlifyPreInit(PreInitContext context) {
+        final ControlifyBindApi registrar = ControlifyBindApi.get();
+        registerCustomRadialIcons();
+        registerInputBindings(registrar);
+        registerScreenProcessors();
+    }
+
+    private enum EpicSkillsRadialIcons {
+        ABILITY_STONE(EpicSkills.rl("textures/item/ability_stone.png"));
+
+        private final @NotNull ResourceLocation id;
+
+        EpicSkillsRadialIcons(@NotNull ResourceLocation id) {
+            this.id = id;
+        }
+
+        public @NotNull ResourceLocation getId() {
+            return id;
+        }
+    }
+
+    private static void registerCustomRadialIcons() {
+        for (EpicSkillsRadialIcons icon : EpicSkillsRadialIcons.values()) {
+            final ResourceLocation location = icon.getId();
+            RadialIcons.registerIcon(location, (graphics, x, y, tickDelta) -> {
+                var pose = CGuiPose.ofPush(graphics);
+                pose.translate(x, y);
+                pose.scale(0.5f, 0.5f);
+                Blit.tex(graphics, location, 0, 0, 0, 0, 32, 32, 32, 32);
+                pose.pop();
+            });
+        }
+    }
+
+    private static void registerInputBindings(ControlifyBindApi registrar) {
+        final Component guiCategory = Component.translatable("key.epicfight.gui");
+        openSkillTreeScreen = registrar.registerBinding(
+                builder -> builder.id(EpicSkills.rl("attack"))
+                        .category(guiCategory)
+                        .allowedContexts(BindContext.IN_GAME)
+                        .name(Component.translatable("key.epicskills.open_skill_tree"))
+                        .description(Component.translatable("key.epicskills.open_skill_tree.description"))
+                        .addKeyCorrelation(EpicSkillsKeyMappings.OPEN_SKILL_TREE)
+                        .keyEmulation(EpicSkillsKeyMappings.OPEN_SKILL_TREE)
+                        .radialCandidate(EpicSkillsRadialIcons.ABILITY_STONE.getId())
+        );
+    }
+
+    private static void registerScreenProcessors() {
+        ScreenProcessorProvider.registerProvider(
+                SkillTreeScreen.class,
+                SkillTreeScreenProcessor::new
+        );
+        ScreenProcessorProvider.registerProvider(
+                SkillInfoScreen.class,
+                SkillInfoScreenProcessor::new
+        );
+    }
+
+    private static class SkillTreeScreenProcessor extends ScreenProcessor<SkillTreeScreen> {
+        public SkillTreeScreenProcessor(SkillTreeScreen screen) {
+            super(screen);
+        }
+
+        @Override
+        public void onControllerUpdate(ControllerEntity controller) {
+            super.onControllerUpdate(controller);
+            updateDisableMouseDragging(ControlifyApi.get().currentInputMode());
+        }
+
+        @Override
+        public VirtualMouseBehaviour virtualMouseBehaviour() {
+            // The skill tree screen does not natively support controllers.
+            // To save development time, we work around this issue by enforcing the virtual mouse.
+            return VirtualMouseBehaviour.ENABLED;
+        }
+
+        @Override
+        public void onInputModeChanged(InputMode mode) {
+            super.onInputModeChanged(mode);
+            // Important to allow dragging when switching to a keyboard
+            updateDisableMouseDragging(mode);
+        }
+
+        private void updateDisableMouseDragging(InputMode mode) {
+            screen.setDisableMouseDragging(mode.isController());
+        }
+    }
+
+    private static class SkillInfoScreenProcessor extends ScreenProcessor<SkillInfoScreen> {
+        public SkillInfoScreenProcessor(SkillInfoScreen screen) {
+            super(screen);
+        }
+
+        private static final InputBindingSupplier ACTION = ControlifyBindings.GUI_PRESS;
+
+        @Override
+        protected void handleButtons(ControllerEntity controller) {
+            if (ACTION.on(controller).guiPressed().get()) {
+                screen.getActionButton().onPress();
+            }
+            super.handleButtons(controller);
+        }
+
+        @Override
+        protected void setInitialFocus() {
+            // No-op
+        }
+
+        @Override
+        protected void handleComponentNavigation(ControllerEntity controller) {
+            // No-op
+        }
+
+        @Override
+        public void onWidgetRebuild() {
+            super.onWidgetRebuild();
+
+            ButtonGuideApi.addGuideToButton(
+                    this.screen.getActionButton(),
+                    ACTION,
+                    ButtonGuidePredicate.always()
+            );
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
+++ b/src/main/resources/META-INF/services/dev.isxander.controlify.api.entrypoint.ControlifyEntrypoint
@@ -1,0 +1,1 @@
+com.yesman.epicskills.compat.controlify.ControlifyCompat

--- a/src/main/resources/assets/epicskills/lang/en_us.json
+++ b/src/main/resources/assets/epicskills/lang/en_us.json
@@ -52,8 +52,9 @@
 	"commands.epicskills.skilltree_progression.failed": "Failed to execute command due to invalid player data",
 	
 	"key.epicskills.gui": "Epic Fight: Skill Tree GUI",
-	
+
 	"key.epicskills.open_skill_tree": "Open Skill Tree",
+    "key.epicskills.open_skill_tree.description": "Opens the Epic Fight skill tree screen",
 	
 	"eof": "eof"
 }


### PR DESCRIPTION
See also https://github.com/Epic-Fight/epicfight/pull/2133

Adds support for the radial menu to open the skill tree and makes the skill tree and info screens playable on controllers.

Not exactly perfect GUI support for controllers, but it’s not bad either — it’s playable and stable. Providing better screen support would require extensive refactoring of the existing screens.

### Video

https://github.com/user-attachments/assets/bedeac64-5acc-4f5e-821d-7f7fcd6c2489

