### PR TITLE
Improve Controlify navigation support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,11 @@
 ## [21.2.3 - Unreleased]
 
 ### Changed:
-- Improved the Controlify compatibility by allowing scaling and moving the viewpoint when using a controller.
+
+- Improved [Controlify mod](https://modrinth.com/mod/controlify) compatibility by allowing:
+    - Scaling and moving the skill tree viewport using the right thumbstick.
+    - Navigating between skill tree pages using the left and right shoulder buttons.
+    - Opening the skill editor using the north button and converting XP to an ability point using the west button.
 
 ## [21.2.2] - 2025-11-01
 

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
@@ -44,6 +44,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
@@ -76,7 +77,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	private final Map<Integer, TreePage> skillTreePages = new HashMap<> ();
 	private final Map<Integer, TreeSelectButton> skillTreeButtons = new HashMap<> ();
 	
-	private final ExpToAbilityPointConverstionButton expConversionButton;
+	public final ExpToAbilityPointConverstionButton expConversionButton;
 	private final Button scaleUpButton;
 	private final Button scaleDownButton;
 	
@@ -310,6 +311,36 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		this.currentPage = this.skillTreePages.get(index);
 		this.relocateScaleButtons();
 	}
+
+    /**
+     * Navigates to the next or previous skill tree page.
+     *
+     * <p>Navigation occurs only if a page exists in the requested direction.</p>
+     *
+     * @param isNextPage {@code true} to move to the next page, {@code false} to move to the previous page
+     * @return {@code true} if navigation succeeded and the current page was updated,
+     *         {@code false} if no page exists in that direction or the current page is invalid
+     */
+    public boolean navigateTreePage(boolean isNextPage) {
+        final int currentPageIndex = skillTreePages.entrySet().stream()
+                .filter(entry -> entry.getValue() == currentPage)
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(-1);
+        if (currentPageIndex == -1) {
+            return false;
+        }
+        final int newIndex = isNextPage ? (currentPageIndex + 1) : (currentPageIndex - 1);
+        final boolean canNavigate = skillTreePages.containsKey(newIndex);
+        if (!canNavigate) {
+            return false;
+        }
+        setTreeIndex(newIndex);
+        skillTreeButtons.forEach((index, button) -> {
+            button.setFocused(index == newIndex);
+        });
+        return true;
+    }
 	
 	public void scaleUp() {
 		int nextScale = Math.min(6, (this.nodeScale == -1 ? (int)this.minecraft.getWindow().getGuiScale() : this.nodeScale) + 1);
@@ -381,7 +412,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 			}, Button.DEFAULT_NARRATION);
 			this.skillTree = skillTree;
 		}
-		
+
 		@Override
 		public void renderWidget(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
 			if (SkillTreeScreen.this.backgroundMode) {
@@ -407,10 +438,14 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		}
 		
 		@Override
-		public void playDownSound(SoundManager pHandler) {
-			pHandler.play(SimpleSoundInstance.forUI(EpicSkillsSounds.HOVER.get(), 1.0F, 1.0F));
+		public void playDownSound(@NotNull SoundManager pHandler) {
+            playSkillTreeDownSound(pHandler);
 		}
 	}
+
+    public static void playSkillTreeDownSound(@NotNull SoundManager manager) {
+        manager.play(SimpleSoundInstance.forUI(EpicSkillsSounds.HOVER.get(), 1.0F, 1.0F));
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	public class ExpToAbilityPointConverstionButton extends AbstractButton {
@@ -425,7 +460,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		}
 		
 		public void tick() {
-			this.active = SkillTreeScreen.this.player.totalExperience >= SkillTreeScreen.this.playerAbilityPoints.getRequiredExp();
+			this.active = canConvert();
 			this.hoverTickO = this.hoverTick;
 			
 			if (this.isHovered() && this.active) {
@@ -481,10 +516,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		
 		@Override
 		public void onPress() {
-			if (!SkillTreeScreen.this.synclock) {
-				EpicFightNetworkManager.sendToServer(new ServerBoundConvertAbilityPointRequest());
-				SkillTreeScreen.this.synclock = true;
-			}
+			convert();
 		}
 		
 		@Override
@@ -495,6 +527,20 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		@Override
 		public void playDownSound(SoundManager handler) {
 		}
+
+        private boolean canConvert() {
+            return SkillTreeScreen.this.player.totalExperience >= SkillTreeScreen.this.playerAbilityPoints.getRequiredExp();
+        }
+
+        public void convert() {
+            if (!isActive()) {
+                return;
+            }
+            if (!SkillTreeScreen.this.synclock) {
+                EpicFightNetworkManager.sendToServer(new ServerBoundConvertAbilityPointRequest());
+                SkillTreeScreen.this.synclock = true;
+            }
+        }
 	}
 	
 	@OnlyIn(Dist.CLIENT)
@@ -518,9 +564,13 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		
 		@Override
 		public void onPress() {
-			minecraft.setScreen(new SkillEditScreen(player, playerSkills));
+            openSkillEditorScreen();
 		}
 	}
+
+    public void openSkillEditorScreen() {
+        Objects.requireNonNull(minecraft).setScreen(new SkillEditScreen(player, playerSkills));
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	public class AbilityPointsMeter extends AbstractWidget {

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
@@ -319,7 +319,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
      *
      * @param isNextPage {@code true} to move to the next page, {@code false} to move to the previous page
      * @return {@code true} if navigation succeeded and the current page was updated,
-     *         {@code false} if no page exists in that direction or the current page is invalid
+     *         {@code false} if no page exists in that direction, tree is locked, or the current page is invalid
      */
     public boolean navigateTreePage(boolean isNextPage) {
         final int currentPageIndex = skillTreePages.entrySet().stream()
@@ -331,7 +331,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
             return false;
         }
         final int newIndex = isNextPage ? (currentPageIndex + 1) : (currentPageIndex - 1);
-        final boolean canNavigate = skillTreePages.containsKey(newIndex);
+        final boolean canNavigate = skillTreePages.containsKey(newIndex) && skillTreeButtons.get(newIndex).isActive();
         if (!canNavigate) {
             return false;
         }

--- a/src/main/java/com/yesman/epicskills/compat/controlify/ControlifyCompat.java
+++ b/src/main/java/com/yesman/epicskills/compat/controlify/ControlifyCompat.java
@@ -23,6 +23,7 @@ import dev.isxander.controlify.utils.render.Blit;
 import dev.isxander.controlify.utils.render.CGuiPose;
 import dev.isxander.controlify.virtualmouse.VirtualMouseBehaviour;
 import dev.isxander.controlify.virtualmouse.VirtualMouseHandler;
+import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -37,6 +38,12 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
     private static InputBindingSupplier scaleSkillTreeUp;
     private static InputBindingSupplier scaleSkillTreeDown;
+
+    private static InputBindingSupplier navigateSkillTreeNext;
+    private static InputBindingSupplier navigateSkillTreePrev;
+
+    private static InputBindingSupplier openSkillEditor;
+    private static InputBindingSupplier convertXpToAbilityPoint;
 
     @Override
     public void onControllersDiscovered(ControlifyApi controlify) {
@@ -151,6 +158,36 @@ public class ControlifyCompat implements ControlifyEntrypoint {
                         .name(Component.translatable("controller.epicskills.scale_skill_tree_down"))
                         .description(Component.translatable("controller.epicskills.scale_skill_tree_down.description"))
         );
+
+        navigateSkillTreeNext = registrar.registerBinding(
+                builder -> builder.id(EpicSkills.rl("navigate_skill_tree_next"))
+                        .category(guiCategory)
+                        .allowedContexts(EpicSkillsBindContext.IN_SKILL_TREE)
+                        .name(Component.translatable("controller.epicskills.navigate_skill_tree_next"))
+                        .description(Component.translatable("controller.epicskills.navigate_skill_tree_next.description"))
+        );
+        navigateSkillTreePrev = registrar.registerBinding(
+                builder -> builder.id(EpicSkills.rl("navigate_skill_tree_prev"))
+                        .category(guiCategory)
+                        .allowedContexts(EpicSkillsBindContext.IN_SKILL_TREE)
+                        .name(Component.translatable("controller.epicskills.navigate_skill_tree_prev"))
+                        .description(Component.translatable("controller.epicskills.navigate_skill_tree_prev.description"))
+        );
+
+        openSkillEditor = registrar.registerBinding(
+                builder -> builder.id(EpicSkills.rl("open_skill_editor"))
+                        .category(guiCategory)
+                        .allowedContexts(EpicSkillsBindContext.IN_SKILL_TREE)
+                        .name(Component.translatable("controller.epicskills.open_skill_editor"))
+                        .description(Component.translatable("controller.epicskills.open_skill_editor.description"))
+        );
+        convertXpToAbilityPoint = registrar.registerBinding(
+                builder -> builder.id(EpicSkills.rl("convert_xp_to_ability_point"))
+                        .category(guiCategory)
+                        .allowedContexts(EpicSkillsBindContext.IN_SKILL_TREE)
+                        .name(Component.translatable("controller.epicskills.convert_xp_to_ability_point"))
+                        .description(Component.translatable("controller.epicskills.convert_xp_to_ability_point.description"))
+        );
     }
 
     private static void registerScreenProcessors() {
@@ -197,6 +234,8 @@ public class ControlifyCompat implements ControlifyEntrypoint {
 
             handleViewportMove(controller, vmouse);
             handleViewportScale(controller);
+            handleTreeNavigation(controller);
+            handleOtherActions(controller);
         }
 
         private void handleViewportMove(@NotNull ControllerEntity controller, @NotNull VirtualMouseHandler vmouse) {
@@ -230,12 +269,41 @@ public class ControlifyCompat implements ControlifyEntrypoint {
         }
 
         private void handleViewportScale(@NotNull ControllerEntity controller) {
-            if (scaleSkillTreeUp.on(controller).guiPressed().get()) {
-                this.screen.scaleUp();
+            final boolean isUp = isPressed(scaleSkillTreeUp, controller);
+            final boolean isDown = isPressed(scaleSkillTreeDown, controller);
+            if (isUp || isDown) {
+                if (isUp) {
+                    this.screen.scaleUp();
+                } else {
+                    this.screen.scaleDown();
+                }
+                playClackSound();
             }
-            if (scaleSkillTreeDown.on(controller).guiPressed().get()) {
-                this.screen.scaleDown();
+        }
+
+        private void handleTreeNavigation(@NotNull ControllerEntity controller) {
+            final boolean isNext = isPressed(navigateSkillTreeNext, controller);
+            final boolean isPrev = isPressed(navigateSkillTreePrev, controller);
+
+            if (isNext || isPrev) {
+                final boolean navigated = this.screen.navigateTreePage(isNext);
+                if (navigated) {
+                    SkillTreeScreen.playSkillTreeDownSound(Minecraft.getInstance().getSoundManager());
+                }
             }
+        }
+
+        private void handleOtherActions(@NotNull ControllerEntity controller) {
+            if (isPressed(openSkillEditor, controller)) {
+                this.screen.openSkillEditorScreen();
+                playClackSound();
+            } else if (isPressed(convertXpToAbilityPoint, controller)) {
+                this.screen.expConversionButton.convert();
+            }
+        }
+
+        private boolean isPressed(@NotNull InputBindingSupplier binding, @NotNull ControllerEntity controller) {
+            return binding.on(controller).guiPressed().get();
         }
     }
 

--- a/src/main/resources/assets/controlify/controllers/default_bind/default.json
+++ b/src/main/resources/assets/controlify/controllers/default_bind/default.json
@@ -13,10 +13,22 @@
       "axis": "controlify:axis/right_stick_left"
     },
     "epicskills:scale_skill_tree_up": {
-      "button": "controlify:button/right_shoulder"
+      "axis": "controlify:axis/right_trigger"
     },
     "epicskills:scale_skill_tree_down": {
+      "axis": "controlify:axis/left_trigger"
+    },
+    "epicskills:navigate_skill_tree_next": {
+      "button": "controlify:button/right_shoulder"
+    },
+    "epicskills:navigate_skill_tree_prev": {
       "button": "controlify:button/left_shoulder"
+    },
+    "epicskills:open_skill_editor": {
+      "button": "controlify:button/north"
+    },
+    "epicskills:convert_xp_to_ability_point": {
+      "button": "controlify:button/west"
     }
   }
 }

--- a/src/main/resources/assets/epicskills/lang/en_us.json
+++ b/src/main/resources/assets/epicskills/lang/en_us.json
@@ -73,5 +73,16 @@
     "controller.epicskills.scale_skill_tree_down": "Scale Skill Tree Down",
     "controller.epicskills.scale_skill_tree_down.description": "Decreases the size of the skill tree when it is open.",
 
-	"eof": "eof"
+    "controller.epicskills.navigate_skill_tree_next": "Next Skill Tree Page",
+    "controller.epicskills.navigate_skill_tree_next.description": "Moves to the next page of the skill tree when it is open.",
+    "controller.epicskills.navigate_skill_tree_prev": "Previous Skill Tree Page",
+    "controller.epicskills.navigate_skill_tree_prev.description": "Moves to the previous page of the skill tree when it is open.",
+
+    "controller.epicskills.open_skill_editor": "Open Skill Editor",
+    "controller.epicskills.open_skill_editor.description": "Opens the skill editor screen from the skill tree.",
+    "controller.epicskills.convert_xp_to_ability_point": "Convert XP to Ability Points",
+    "controller.epicskills.convert_xp_to_ability_point.description": "Exchanges XP for skill points when the skill tree is open.",
+
+
+  "eof": "eof"
 }


### PR DESCRIPTION
- Improved [Controlify mod](https://modrinth.com/mod/controlify) compatibility by allowing:
    - Scaling using the triggers, and moving the skill tree viewport using the right thumbstick.
    - Navigating between skill tree pages using the left and right shoulder buttons.
    - Opening the skill editor using the north button and converting XP to an ability point using the west button.
- Some minor cleanup for the `SkillEditorScreen` (related changes only). **The vanilla behavior is unchanged.**
- Documented the changes for the next release.


I have also confirmed that the player can't open a locked skill tree page, using a controller or keyboard/mouse.


https://github.com/user-attachments/assets/16276f06-d343-4010-b26a-16aab8532cdf

