### PR TITLE
[Forge 1.20.1] Backport changes from NeoForge 1.20.1 for controller support

### DIFF
--- a/src/main/java/com/yesman/epicskills/EpicSkills.java
+++ b/src/main/java/com/yesman/epicskills/EpicSkills.java
@@ -1,7 +1,5 @@
 package com.yesman.epicskills;
 
-import org.slf4j.Logger;
-
 import com.mojang.logging.LogUtils;
 import com.yesman.epicskills.client.gui.screen.CategorySlotTexture;
 import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
@@ -15,7 +13,7 @@ import com.yesman.epicskills.skilltree.SkillTree;
 import com.yesman.epicskills.skilltree.SkillTreeEntry;
 import com.yesman.epicskills.world.capability.AbilityPoints;
 import com.yesman.epicskills.world.capability.SkillTreeProgression;
-
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
@@ -28,6 +26,8 @@ import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DataPackRegistryEvent;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 import yesman.epicfight.main.EpicFightSharedConstants;
 import yesman.epicfight.world.item.EpicFightCreativeTabs;
 
@@ -111,4 +111,8 @@ public class EpicSkills {
         	event.enqueueWork(CategorySlotTexture.ENUM_MANAGER::loadEnum);
         }
 	}
+
+    public static @NotNull ResourceLocation rl(@NotNull final String path) {
+        return ResourceLocation.fromNamespaceAndPath(MODID, path);
+    }
 }

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillInfoScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillInfoScreen.java
@@ -1,7 +1,5 @@
 package com.yesman.epicskills.client.gui.screen;
 
-import java.util.Set;
-
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.yesman.epicskills.EpicSkills;
 import com.yesman.epicskills.network.NetworkManager;
@@ -10,7 +8,6 @@ import com.yesman.epicskills.network.server.ServerBoundUnlockSkillRequest;
 import com.yesman.epicskills.skilltree.SkillTree;
 import com.yesman.epicskills.world.capability.AbilityPoints;
 import com.yesman.epicskills.world.capability.SkillTreeProgression;
-
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
@@ -31,6 +28,8 @@ import yesman.epicfight.network.client.CPChangeSkill;
 import yesman.epicfight.skill.SkillContainer;
 import yesman.epicfight.world.gamerule.EpicFightGameRules;
 
+import java.util.Set;
+
 @OnlyIn(Dist.CLIENT)
 public class SkillInfoScreen extends SkillBookScreen {
 	private static final ResourceLocation SKILLBOOK_BACKGROUND = ResourceLocation.fromNamespaceAndPath(EpicFightMod.MODID, "textures/gui/screen/skillbook.png");
@@ -39,6 +38,11 @@ public class SkillInfoScreen extends SkillBookScreen {
 	private final SkillTreeProgression.TopDownTreeNode node;
 	private final AbilityPoints abilityPoints;
 	private boolean backgroundMode;
+    private Button actionButton;
+
+    public Button getActionButton() {
+        return actionButton;
+    }
 	
 	public SkillInfoScreen(Player opener, Holder.Reference<SkillTree> skillTree, SkillTreeProgression.TopDownTreeNode node, Screen parentScreen) {
 		super(opener, node.nodeInfo().skill(), null, parentScreen);
@@ -81,7 +85,7 @@ public class SkillInfoScreen extends SkillBookScreen {
 			active = false;
 		}
 		
-		Button actionButton =
+		actionButton =
 			Button.builder(
 				message,
 				button -> {

--- a/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
+++ b/src/main/java/com/yesman/epicskills/client/gui/screen/SkillTreeScreen.java
@@ -1,23 +1,8 @@
 package com.yesman.epicskills.client.gui.screen;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.function.Function;
-
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.apache.logging.log4j.Logger;
-
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.BufferUploader;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.Tesselator;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.*;
 import com.mojang.datafixers.util.Pair;
 import com.yesman.epicskills.EpicSkills;
 import com.yesman.epicskills.client.gui.screen.SkillTreeScreen.TreePage.NodeButton;
@@ -32,7 +17,6 @@ import com.yesman.epicskills.world.capability.SkillTreeProgression;
 import com.yesman.epicskills.world.capability.SkillTreeProgression.ImportedNode;
 import com.yesman.epicskills.world.capability.SkillTreeProgression.NodeState;
 import com.yesman.epicskills.world.capability.SkillTreeProgression.TopDownTreeNode;
-
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -61,6 +45,9 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import yesman.epicfight.api.utils.ParseUtil;
 import yesman.epicfight.api.utils.math.Vec2i;
 import yesman.epicfight.client.gui.screen.SkillEditScreen;
@@ -69,6 +56,9 @@ import yesman.epicfight.main.EpicFightMod;
 import yesman.epicfight.skill.Skill;
 import yesman.epicfight.world.capabilities.skill.CapabilitySkill;
 import yesman.epicfight.world.item.EpicFightItems;
+
+import java.util.*;
+import java.util.function.Function;
 
 @OnlyIn(Dist.CLIENT)
 public class SkillTreeScreen extends Screen implements BackgroundRenderableScreen {
@@ -99,6 +89,10 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	private boolean backgroundMode;
 	private boolean synclock;
 	private boolean discarded = false;
+    /**
+     * Whether to ignore {@link SkillTreeScreen#mouseDragged} calls.
+     */
+    private boolean disableMouseDragging = false;
 	
 	private int nodeScale = -1;
 	
@@ -283,14 +277,21 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 	
 	@Override
 	public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+        if (isDisableMouseDragging()) {
+            return false;
+        }
 		if (!super.mouseDragged(mouseX, mouseY, button, dragX, dragY)) {
-			this.currentPage.pageLeft += dragX;
-			this.currentPage.pageTop += dragY;
+            moveViewport((float) dragX, (float) dragY);
 			return false;
 		}
 		
 		return true;
 	}
+
+    public void moveViewport(float deltaX, float deltaY) {
+        this.currentPage.pageLeft += deltaX;
+        this.currentPage.pageTop += deltaY;
+    }
 	
 	@Override
 	public boolean mouseScrolled(double x, double y, double wheel) {
@@ -311,6 +312,36 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		this.currentPage = this.skillTreePages.get(index);
 		this.relocateScaleButtons();
 	}
+
+    /**
+     * Navigates to the next or previous skill tree page.
+     *
+     * <p>Navigation occurs only if a page exists in the requested direction.</p>
+     *
+     * @param isNextPage {@code true} to move to the next page, {@code false} to move to the previous page
+     * @return {@code true} if navigation succeeded and the current page was updated,
+     *         {@code false} if no page exists in that direction, tree is locked, or the current page is invalid
+     */
+    public boolean navigateTreePage(boolean isNextPage) {
+        final int currentPageIndex = skillTreePages.entrySet().stream()
+                .filter(entry -> entry.getValue() == currentPage)
+                .map(Map.Entry::getKey)
+                .findFirst()
+                .orElse(-1);
+        if (currentPageIndex == -1) {
+            return false;
+        }
+        final int newIndex = isNextPage ? (currentPageIndex + 1) : (currentPageIndex - 1);
+        final boolean canNavigate = skillTreePages.containsKey(newIndex) && skillTreeButtons.get(newIndex).isActive();
+        if (!canNavigate) {
+            return false;
+        }
+        setTreeIndex(newIndex);
+        skillTreeButtons.forEach((index, button) -> {
+            button.setFocused(index == newIndex);
+        });
+        return true;
+    }
 	
 	public void scaleUp() {
 		int nextScale = Math.min(6, (this.nodeScale == -1 ? (int)this.minecraft.getWindow().getGuiScale() : this.nodeScale) + 1);
@@ -351,10 +382,22 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 			this.synclock = false;
 		}
 	}
-	
-	public boolean discarded() {
+
+    public ExpToAbilityPointConverstionButton getExpConversionButton() {
+        return expConversionButton;
+    }
+
+    public boolean discarded() {
 		return this.discarded;
 	}
+
+    public boolean isDisableMouseDragging() {
+        return disableMouseDragging;
+    }
+
+    public void setDisableMouseDragging(boolean disableMouseDragging) {
+        this.disableMouseDragging = disableMouseDragging;
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	public class TreeSelectButton extends Button implements HoverSoundPlayer {
@@ -400,10 +443,14 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		}
 		
 		@Override
-		public void playDownSound(SoundManager pHandler) {
-			pHandler.play(SimpleSoundInstance.forUI(EpicSkillsSounds.HOVER.get(), 1.0F, 1.0F));
+		public void playDownSound(@NotNull SoundManager pHandler) {
+            playSkillTreeDownSound(pHandler);
 		}
 	}
+
+    public static void playSkillTreeDownSound(@NotNull SoundManager manager) {
+        manager.play(SimpleSoundInstance.forUI(EpicSkillsSounds.HOVER.get(), 1.0F, 1.0F));
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	public class ExpToAbilityPointConverstionButton extends AbstractButton {
@@ -418,7 +465,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		}
 		
 		public void tick() {
-			this.active = SkillTreeScreen.this.player.totalExperience >= SkillTreeScreen.this.playerAbilityPoints.getRequiredExp();
+            this.active = canConvert();
 			this.hoverTickO = this.hoverTick;
 			
 			if (this.isHovered() && this.active) {
@@ -474,10 +521,7 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		
 		@Override
 		public void onPress() {
-			if (!SkillTreeScreen.this.synclock) {
-				NetworkManager.sendToServer(new ServerBoundConvertAbilityPointRequest());
-				SkillTreeScreen.this.synclock = true;
-			}
+			convert();
 		}
 		
 		@Override
@@ -488,6 +532,24 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		@Override
 		public void playDownSound(SoundManager handler) {
 		}
+
+        private boolean canConvert() {
+            return SkillTreeScreen.this.player.totalExperience >= SkillTreeScreen.this.playerAbilityPoints.getRequiredExp();
+        }
+
+        public void convert() {
+            if (!isActive()) {
+                // Ensure conversion only occurs when active.
+                // This is important when convert() is called directly (e.g., via controller input).
+                // Without this check, the player could lose XP without gaining
+                // an ability point if they don't have enough XP.
+                return;
+            }
+            if (!SkillTreeScreen.this.synclock) {
+                NetworkManager.sendToServer(new ServerBoundConvertAbilityPointRequest());
+                SkillTreeScreen.this.synclock = true;
+            }
+        }
 	}
 	
 	@OnlyIn(Dist.CLIENT)
@@ -511,9 +573,13 @@ public class SkillTreeScreen extends Screen implements BackgroundRenderableScree
 		
 		@Override
 		public void onPress() {
-			minecraft.setScreen(new SkillEditScreen(player, playerSkills));
+            openSkillEditorScreen();
 		}
 	}
+
+    public void openSkillEditorScreen() {
+        Objects.requireNonNull(minecraft).setScreen(new SkillEditScreen(player, playerSkills));
+    }
 	
 	@OnlyIn(Dist.CLIENT)
 	public class AbilityPointsMeter extends AbstractWidget {

--- a/src/main/java/com/yesman/epicskills/mixin/MixinControlEngine.java
+++ b/src/main/java/com/yesman/epicskills/mixin/MixinControlEngine.java
@@ -1,27 +1,19 @@
 package com.yesman.epicskills.mixin;
 
+import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
+import com.yesman.epicskills.client.input.EpicSkillsKeyMappings;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
-import com.yesman.epicskills.client.input.EpicSkillsKeyMappings;
-
-import net.minecraft.client.KeyMapping;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.player.LocalPlayer;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
 @Mixin(value = ControlEngine.class)
 public class MixinControlEngine {
-	@Shadow
-	private LocalPlayer player;
-	
-	@Shadow
-	private Minecraft minecraft;
 	
 	@Shadow(remap = false)
 	private LocalPlayerPatch playerPatch;
@@ -36,7 +28,8 @@ public class MixinControlEngine {
 				SkillTreeScreen skilltreescreen = new SkillTreeScreen(this.playerPatch);
 				
 				if (!skilltreescreen.discarded()) {
-					this.minecraft.setScreen(skilltreescreen);
+                    final Minecraft minecraft = Minecraft.getInstance();
+					minecraft.setScreen(skilltreescreen);
 				}
 			}
 		}


### PR DESCRIPTION
Backport the screen changes from #5, #7, and #8 to Forge 1.20.1.

This refactoring is useful for consistency, so addons can depend on the same APIs in both MC versions, which is useful for my new addon that adds Controlify 1.20.1 support.

> [!NOTE]
> I also made an unrelated change in the second commit, which fixes a runtime mixin issue. This was already an issue. I normally send a separate PR for that, but since I need to make that for the NeoForge 1.2.1.1 branch, this would make a lot of noise, so I just pushed it in a separate commit.