### PR TITLE
[1.21.1] Migrate from deprecated Epic Fight API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,8 @@
 
 ### For Devs
 - Adopted KeyConflictContext for each keybind as documented by [Neoforge](https://docs.neoforged.net/docs/misc/keymappings/#ikeyconflictcontext) to avoid potential problem from inconsistency
+- Avoid shadowing the private `ControlEngine#playerpatch` property from Epic Fight; instead, depend on the public `getPlayerPatch()` instead to avoid future breakage.
+- Avoid depending on the deprecated `ControlEngine#isKeyDown` to avoid future breakage.
 
 ## [21.2.3] - 2025-11-04
 

--- a/src/main/java/com/yesman/epicskills/mixin/MixinControlEngine.java
+++ b/src/main/java/com/yesman/epicskills/mixin/MixinControlEngine.java
@@ -1,38 +1,38 @@
 package com.yesman.epicskills.mixin;
 
+import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
+import com.yesman.epicskills.client.input.EpicSkillsKeyMappings;
 import net.minecraft.client.Minecraft;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import com.yesman.epicskills.client.gui.screen.SkillTreeScreen;
-import com.yesman.epicskills.client.input.EpicSkillsKeyMappings;
-
-import net.minecraft.client.KeyMapping;
 import yesman.epicfight.client.events.engine.ControlEngine;
 import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 
 @Mixin(value = ControlEngine.class)
 public class MixinControlEngine {
-	@Shadow(remap = false)
-	private LocalPlayerPatch playerpatch;
-	
-	@Shadow(remap = false)
-	private static boolean isKeyPressed(KeyMapping key, boolean eventCheck) { throw new AbstractMethodError(); }
-	
 	@Inject(at = @At(value = "HEAD"), method = "handleEpicFightKeyMappings()V", remap = false)
 	public void epicskills$handleEpicFightKeyMappings(CallbackInfo callbackInfo) {
-		if (this.playerpatch != null) {
-			if (isKeyPressed(EpicSkillsKeyMappings.OPEN_SKILL_TREE, false)) {
-				SkillTreeScreen skilltreescreen = new SkillTreeScreen(this.playerpatch);
-				
-				if (!skilltreescreen.discarded()) {
-                    final Minecraft minecraft = Minecraft.getInstance();
-                    minecraft.setScreen(skilltreescreen);
-				}
-			}
-		}
+        final ControlEngine controlEngine = ((ControlEngine) (Object) this);
+        final LocalPlayerPatch localPlayerPatch = controlEngine.getPlayerPatch();
+        if (localPlayerPatch == null) {
+            return;
+        }
+        while (EpicSkillsKeyMappings.OPEN_SKILL_TREE.consumeClick()) {
+            epicskills$openSkillTree(localPlayerPatch);
+        }
 	}
+
+    @Unique
+    private void epicskills$openSkillTree(@NotNull LocalPlayerPatch localPlayerPatch) {
+        SkillTreeScreen skilltreescreen = new SkillTreeScreen(localPlayerPatch);
+        if (skilltreescreen.discarded()) {
+            return;
+        }
+        final Minecraft minecraft = Minecraft.getInstance();
+        minecraft.setScreen(skilltreescreen);
+    }
 }


### PR DESCRIPTION
### Changes

- Avoid shadowing the private `ControlEngine#playerpatch` property from Epic Fight; instead, depend on the public `getPlayerPatch()` instead to avoid future breakage.
- Avoid depending on the deprecated `ControlEngine#isKeyDown` to avoid future breakage.
- Keep the code more modular by separating "when it happens" from "how it happens" for opening the skill tree.

This change is necessary, so most users update and continue using the updated APIs, so we can remove the deprecated APIs in future versions of Epic Fight when most users use newer versions.

This also makes sure not to use `@Shadow` since that can be problematic in development environments; it's better to avoid it whenever possible.

Also, avoid depending on the internal private `ControlEngine#playerpatch` since that makes the Skill tree prone to breaking changes if it is changed or removed.

> [!TIP]
> IMO, it would be if we don't depend on Epic Fight `ControlEngine`, and instead on `Minecraft` directly to call this method and handle the skill tree opening, so we can change `ControlEngine#handleEpicFightKeyMappings` without breaking the skill tree, but I didn't make that change.

### Testing

Tested with a controller and vanilla mouse/keyboard.